### PR TITLE
参加者リストの公開/非公開

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -42,7 +42,7 @@ class EventsController < ApplicationController
   private
     def events_params
       params.require(:event).permit(
-        :title, :description,
+        :title, :description, :participant_public_flg,
         tickets_attributes: [:name, :price, :capacity]
     )
     end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -18,6 +18,10 @@
       <%= tf.number_field :capacity %>
     <% end %>
   </div>
+  <div>
+    <%= f.label :参加者リストを公開する %>
+    <%= f.check_box :participant_public_flg %> (※イベントページに参加者リストを表示する場合にはチェックしてください。)
+  </div>
 
   <%= f.submit '投稿' %>
 <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -28,7 +28,7 @@
 <p><%= @event.owners.first.name %></p>
 
 <h3>参加者一覧</h3>
-<% if @event.participants.present? %>
+<% if @event.participant_public_flg? && @event.participants.present? %>
   <table>
     <% @event.participants.each do |participant| %>
       <% unless participant.kicked_out_at %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -28,19 +28,23 @@
 <p><%= @event.owners.first.name %></p>
 
 <h3>参加者一覧</h3>
-<% if @event.participant_public_flg? && @event.participants.present? %>
-  <table>
-    <% @event.participants.each do |participant| %>
-      <% unless participant.kicked_out_at %>
-        <tr>
-          <td><%= "#{participant.user.name} (ID:#{participant.user.id})" %></td>
-          <% if user_signed_in? && current_user.owner?(@event) %>
-            <td>
-              <%= button_to "追い出す", kick_out_participant_path(participant) %>
-            </td>
-          <% end %>
-        </tr>
+<% if @event.participant_public_flg? %>
+  <% if @event.participants.present? %>
+    <table>
+      <% @event.participants.each do |participant| %>
+        <% unless participant.kicked_out_at %>
+          <tr>
+            <td><%= "#{participant.user.name} (ID:#{participant.user.id})" %></td>
+            <% if user_signed_in? && current_user.owner?(@event) %>
+              <td>
+                <%= button_to "追い出す", kick_out_participant_path(participant) %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
       <% end %>
-    <% end %>
-  </table>
+    </table>
+  <% end %>
+<% else %>
+  <p>このイベントの参加者リストは非公開です。</p>
 <% end %>

--- a/db/migrate/20170816111417_add_participant_public_flg_to_event.rb
+++ b/db/migrate/20170816111417_add_participant_public_flg_to_event.rb
@@ -1,0 +1,5 @@
+class AddParticipantPublicFlgToEvent < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events, :participant_public_flg, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170802102143) do
+ActiveRecord::Schema.define(version: 20170816111417) do
 
   create_table "event_owners", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "user_id"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20170802102143) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "participant_public_flg", default: true, null: false
   end
 
   create_table "participants", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
・イベント作成時に、参加者リストを公開するかどうかを選べるようにする
・Eventモデルにparticipant_public_flgカラムを追加（boolean, default: true）

１枚目：チェックボックスが追加されてる。
２枚目：チェックボックスをはずした状態で、イベントを作成後、参加ボタンをおしても「参加者一覧」になにも表示されない

![2017-08-16 20 29 53](https://user-images.githubusercontent.com/6888594/29361300-f430ee78-82c1-11e7-953c-975af11db8b0.png)
![2017-08-16 20 35 20](https://user-images.githubusercontent.com/6888594/29361398-753c5a16-82c2-11e7-97c5-66f2e113a6ba.png)

