### PR TITLE
Add column to event model

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -42,7 +42,7 @@ class EventsController < ApplicationController
   private
     def events_params
       params.require(:event).permit(
-        :title, :description, :participant_public_flg,
+        :title, :description, :content, :start_time, :end_time, :participant_public_flg,
         tickets_attributes: [:name, :price, :capacity]
     )
     end

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -6,6 +6,14 @@
 
     <%= f.label :概要 %>
     <%= f.text_field :description, value: @copy&.description %>
+    <br>
+    <%= f.label :内容 %>
+    <%= f.text_area :content, value: @copy&.content %>
+    <br>
+    <%= f.label :開始時間 %>
+    <%= f.datetime_local_field :start_time %>
+    <%= f.label :終了時間 %>
+    <%= f.datetime_local_field :end_time %>
   </div>
   <h3>チケット</h3>
   <div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -11,6 +11,18 @@
     <td>概要</td>
     <td><%= @event.description %></td>
   </tr>
+  <tr>
+    <td>内容</td>
+    <td><%= @event.content %></td>
+  </tr>
+  <tr>
+    <td>開始時間</td>
+    <td><%= @event.start_time %></td>
+  </tr>
+  <tr>
+    <td>終了時間</td>
+    <td><%= @event.end_time %></td>
+  </tr>
 </table>
 
 <% if user_signed_in? %>

--- a/db/migrate/20170819052441_add_columns_to_event.rb
+++ b/db/migrate/20170819052441_add_columns_to_event.rb
@@ -1,0 +1,7 @@
+class AddColumnsToEvent < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events, :content, :text
+    add_column :events, :start_time, :datetime
+    add_column :events, :end_time, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170816111417) do
+ActiveRecord::Schema.define(version: 20170819052441) do
 
   create_table "event_owners", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "user_id"
@@ -29,6 +29,9 @@ ActiveRecord::Schema.define(version: 20170816111417) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "participant_public_flg", default: true, null: false
+    t.text "content"
+    t.datetime "start_time"
+    t.datetime "end_time"
   end
 
   create_table "participants", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
#9 
下記カラムをEventモデルへ追加しました。
日付入力のインターフェースはHTML5の機能を使ってます（若干格好悪い・・・）
内容：content, text
開始時間：start_time, datetime
終了時間：end_time, datetime

![2017-08-23 20 06 06](https://user-images.githubusercontent.com/6888594/29613096-5154325e-883f-11e7-8c5e-58db0e38707a.png)
